### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-FED3 is an open-source battery-powered device for home-cage training of mice in operant tasks. FED3 can be [3D printed](https://github.com/KravitzLabDevices/FED3/tree/main/3Dfiles) and the control code is open-source and can be modified. The [code](https://github.com/KravitzLabDevices/FED3/tree/main/ArduinoCode) is written in the [Arduino](https://www.arduino.cc/) language and is run on a [Feather M0 Adalogger](https://www.adafruit.com/product/2796) microcontroller inside of FED3.  For information on how to build and use FED3 check out the [Wiki](https://github.com/KravitzLabDevices/FED3/wiki), and the [Google group](https://groups.google.com/forum/#!forum/fedforum).
+FED3 is an open-source battery-powered device for home-cage training of mice in operant tasks. FED3 can be [3D printed](https://github.com/KravitzLabDevices/FED3/tree/main/3Ddesigns) and the control code is open-source and can be modified. The [code](https://github.com/KravitzLabDevices/FED3/tree/main/ArduinoCode) is written in the [Arduino](https://www.arduino.cc/) language and is run on a [Feather M0 Adalogger](https://www.adafruit.com/product/2796) microcontroller inside of FED3.  For information on how to build and use FED3 check out the [Wiki](https://github.com/KravitzLabDevices/FED3/wiki), and the [Google group](https://groups.google.com/forum/#!forum/fedforum).
 
 Mice interact with FED3 through two nose-pokes and FED3 responds with visual stimuli, auditory stimuli, and by dispensing pellets. FED3 also has an analog output that allows it to synchronize with and control external equipment such as lasers or brain recording systems. A screen provides feedback to the user, and all behavioral events are logged to an on-board microSD card. 
 


### PR DESCRIPTION
Thanks so much for the design! I just noticed that one of the links in the README was set to an older directory name. Super minor change.